### PR TITLE
fix: keep route on subrouter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,15 @@ const parseUrl = ({ url }) => {
   }
 }
 
+const QUESTION_MARK_CHAR_CODE = 63
+
 const mutateRequestUrl = (prefix, req) => {
-  req.url = req.url.substring(prefix.length) || '/'
-  req.path = req.path.substring(prefix.length) || '/'
+  const remainingUrl = req.url.substring(prefix.length)
+  req.url = !remainingUrl || remainingUrl.charCodeAt(0) === QUESTION_MARK_CHAR_CODE
+    ? `/${remainingUrl}`
+    : remainingUrl
+  const remainingPath = req.path.substring(prefix.length)
+  req.path = remainingPath || '/'
 }
 
 module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {

--- a/test/index.js
+++ b/test/index.js
@@ -801,3 +801,36 @@ test('decodes parameters in path', async t => {
   const response = await got(new URL('/greetings/kiko%20beats', url).toString())
   t.is(response, 'Hello, kiko beats')
 })
+
+test('.use() sub-router matches base path with query string', async t => {
+  const router = Router(final)
+  const subRouter = Router(final)
+
+  subRouter.get('/', (req, res) => res.end('sub-root'))
+  subRouter.get('/success', (req, res) => res.end('sub-success'))
+
+  router.use('/checkout', subRouter)
+
+  const url = await runServer(t, router)
+
+  t.is(
+    await got(new URL('/checkout', url).toString()),
+    'sub-root',
+    '/checkout without query string'
+  )
+  t.is(
+    await got(new URL('/checkout?token=abc123', url).toString()),
+    'sub-root',
+    '/checkout with query string should still match sub-router root'
+  )
+  t.is(
+    await got(new URL('/checkout/success', url).toString()),
+    'sub-success',
+    '/checkout/success without query string'
+  )
+  t.is(
+    await got(new URL('/checkout/success?session_id=cs_test', url).toString()),
+    'sub-success',
+    '/checkout/success with query string'
+  )
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core URL/path mutation for sub-router mounting; a small logic change could affect routing behavior for mounted middleware, especially around edge-case URLs.
> 
> **Overview**
> Fixes URL rewriting for `.use('/prefix', subRouter)` so when the remaining URL is empty *or starts with a query string* (e.g. `/checkout?token=...`), the forwarded `req.url` keeps a leading `/` instead of becoming just `?token=...`, allowing the sub-router to match its `/` route.
> 
> Adds a regression test covering `/checkout` and `/checkout/success` with and without query strings to ensure mounted sub-routers continue to match correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4793f5469a41afd455940aefd6203ab6ffd26875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->