### PR TITLE
fix: match .use() mounts by decoded longest prefix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,68 @@ const requiredFinalHandler = () => {
 const ensureLeadingSlash = route =>
   route.charCodeAt(0) === SLASH_CHAR_CODE ? route : `/${route}`
 
-const getFirstPathSegment = pathname => {
-  const secondSlashIndex = pathname.indexOf('/', 1)
-  return secondSlashIndex > 1
-    ? pathname.substring(0, secondSlashIndex)
-    : pathname
+// Strip trailing slashes so `.use('/admin/', …)` registers under `/admin`.
+const normalizeMountPath = path => {
+  const withSlash = ensureLeadingSlash(path)
+  let end = withSlash.length
+  while (end > 1 && withSlash.charCodeAt(end - 1) === SLASH_CHAR_CODE) {
+    end--
+  }
+  return end === withSlash.length ? withSlash : withSlash.substring(0, end)
+}
+
+const decodePathname = pathname => {
+  try {
+    return decodeURIComponent(pathname)
+  } catch {
+    return pathname
+  }
+}
+
+const countSegments = path => {
+  if (path.length <= 1) return 0
+  let count = 1
+  for (let i = 1; i < path.length; i++) {
+    if (path.charCodeAt(i) === SLASH_CHAR_CODE) count++
+  }
+  return count
+}
+
+// Return the raw URL prefix covering `segmentCount` segments so encoded mounts
+// (e.g. `/%61dmin/panel`) strip the same span as the decoded mount `/admin/panel`.
+const getRawMountPrefix = (pathname, segmentCount) => {
+  if (segmentCount <= 0) return ''
+  let count = 0
+  let i = 1
+  while (i < pathname.length) {
+    const next = pathname.indexOf('/', i)
+    count++
+    if (count === segmentCount) {
+      return next === -1 ? pathname : pathname.substring(0, next)
+    }
+    if (next === -1) return pathname
+    i = next + 1
+  }
+  return pathname
+}
+
+// Match the longest registered mount against the decoded pathname so multi-segment
+// and percent-encoded `.use()` mounts are not skipped while routes still match.
+const matchPathMiddleware = (pathname, middlewaresByPath) => {
+  const decoded = decodePathname(pathname)
+  let matchedPath
+  let matchedMw
+
+  for (const mountPath in middlewaresByPath) {
+    if (decoded === mountPath || decoded.startsWith(mountPath + '/')) {
+      if (matchedPath === undefined || mountPath.length > matchedPath.length) {
+        matchedPath = mountPath
+        matchedMw = middlewaresByPath[mountPath]
+      }
+    }
+  }
+
+  return matchedMw
 }
 
 const parseUrl = ({ url }) => {
@@ -110,8 +167,6 @@ module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {
     const pathname = urlInfo.pathname
     req.path = pathname
 
-    const pathSegment = getFirstPathSegment(pathname)
-
     let route = findRoute(req.method, pathname)
 
     if (route.handlers.length === 0 && req.method === 'HEAD') {
@@ -119,7 +174,7 @@ module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {
     }
 
     const globalMw = globalMiddlewares
-    const pathMw = middlewaresByPath[pathSegment]
+    const pathMw = matchPathMiddleware(pathname, middlewaresByPath)
     const routeHandlers = route.handlers.length > 0 ? route.handlers : null
 
     if (routeHandlers !== null) {
@@ -205,7 +260,7 @@ module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {
         globalMiddlewares.push(middlewares[i])
       }
     } else {
-      const normalizedPath = ensureLeadingSlash(path)
+      const normalizedPath = normalizeMountPath(path)
       const middlewares = fns.filter(Boolean)
 
       if (middlewares.length > 0) {
@@ -213,8 +268,11 @@ module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {
 
         if (pathMiddlewares === undefined) {
           pathMiddlewares = []
+          const mountSegments = countSegments(normalizedPath)
+          // Strip the request's raw mount prefix (may still be percent-encoded),
+          // not `normalizedPath.length`, which cuts the wrong span for encoded URLs.
           pathMiddlewares.push((req, _, next) => {
-            mutateRequestUrl(normalizedPath, req)
+            mutateRequestUrl(getRawMountPrefix(req.path, mountSegments), req)
             next()
           })
           middlewaresByPath[normalizedPath] = pathMiddlewares

--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,12 @@ const normalizeMountPath = path => {
   return end === withSlash.length ? withSlash : withSlash.substring(0, end)
 }
 
-// Skip decodeURIComponent on the common unescaped path (no try/catch either).
+// decodeURI (not decodeURIComponent): leave %2F encoded so it cannot invent
+// path segments and desync mount match from raw segment stripping.
 const decodePathname = pathname => {
   if (pathname.indexOf('%') === -1) return pathname
   try {
-    return decodeURIComponent(pathname)
+    return decodeURI(pathname)
   } catch {
     return pathname
   }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,13 @@ const requiredFinalHandler = () => {
 const ensureLeadingSlash = route =>
   route.charCodeAt(0) === SLASH_CHAR_CODE ? route : `/${route}`
 
-// Strip trailing slashes so `.use('/admin/', …)` registers under `/admin`.
+const getFirstPathSegment = pathname => {
+  const secondSlashIndex = pathname.indexOf('/', 1)
+  return secondSlashIndex > 1
+    ? pathname.substring(0, secondSlashIndex)
+    : pathname
+}
+
 const normalizeMountPath = path => {
   const withSlash = ensureLeadingSlash(path)
   let end = withSlash.length
@@ -35,7 +41,9 @@ const normalizeMountPath = path => {
   return end === withSlash.length ? withSlash : withSlash.substring(0, end)
 }
 
+// Skip decodeURIComponent on the common unescaped path (no try/catch either).
 const decodePathname = pathname => {
+  if (pathname.indexOf('%') === -1) return pathname
   try {
     return decodeURIComponent(pathname)
   } catch {
@@ -43,19 +51,8 @@ const decodePathname = pathname => {
   }
 }
 
-const countSegments = path => {
-  if (path.length <= 1) return 0
-  let count = 1
-  for (let i = 1; i < path.length; i++) {
-    if (path.charCodeAt(i) === SLASH_CHAR_CODE) count++
-  }
-  return count
-}
-
-// Return the raw URL prefix covering `segmentCount` segments so encoded mounts
-// (e.g. `/%61dmin/panel`) strip the same span as the decoded mount `/admin/panel`.
+// Encoded mounts differ in byte length from the registered path; take N raw segments.
 const getRawMountPrefix = (pathname, segmentCount) => {
-  if (segmentCount <= 0) return ''
   let count = 0
   let i = 1
   while (i < pathname.length) {
@@ -68,25 +65,6 @@ const getRawMountPrefix = (pathname, segmentCount) => {
     i = next + 1
   }
   return pathname
-}
-
-// Match the longest registered mount against the decoded pathname so multi-segment
-// and percent-encoded `.use()` mounts are not skipped while routes still match.
-const matchPathMiddleware = (pathname, middlewaresByPath) => {
-  const decoded = decodePathname(pathname)
-  let matchedPath
-  let matchedMw
-
-  for (const mountPath in middlewaresByPath) {
-    if (decoded === mountPath || decoded.startsWith(mountPath + '/')) {
-      if (matchedPath === undefined || mountPath.length > matchedPath.length) {
-        matchedPath = mountPath
-        matchedMw = middlewaresByPath[mountPath]
-      }
-    }
-  }
-
-  return matchedMw
 }
 
 const parseUrl = ({ url }) => {
@@ -121,6 +99,31 @@ module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {
 
   const globalMiddlewares = []
   const middlewaresByPath = new NullProtoObj()
+  // First decoded segment → mounts under that segment, longest path first.
+  const mountsByFirstSegment = new NullProtoObj()
+  let pathMountCount = 0
+
+  const matchPathMiddleware = pathname => {
+    if (pathMountCount === 0) return undefined
+
+    const decoded = decodePathname(pathname)
+    const candidates = mountsByFirstSegment[getFirstPathSegment(decoded)]
+    if (candidates === undefined) return undefined
+
+    for (let i = 0; i < candidates.length; i++) {
+      const mountPath = candidates[i].path
+      const mountLen = mountPath.length
+      if (
+        decoded === mountPath ||
+        (decoded.length > mountLen &&
+          decoded.charCodeAt(mountLen) === SLASH_CHAR_CODE &&
+          decoded.startsWith(mountPath))
+      ) {
+        return candidates[i].mw
+      }
+    }
+    return undefined
+  }
 
   const findRoute = (method, path, constraints) => {
     const result = router.find(method, path, constraints)
@@ -174,7 +177,7 @@ module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {
     }
 
     const globalMw = globalMiddlewares
-    const pathMw = matchPathMiddleware(pathname, middlewaresByPath)
+    const pathMw = matchPathMiddleware(pathname)
     const routeHandlers = route.handlers.length > 0 ? route.handlers : null
 
     if (routeHandlers !== null) {
@@ -268,14 +271,33 @@ module.exports = (finalhandler = requiredFinalHandler(), options = {}) => {
 
         if (pathMiddlewares === undefined) {
           pathMiddlewares = []
-          const mountSegments = countSegments(normalizedPath)
-          // Strip the request's raw mount prefix (may still be percent-encoded),
-          // not `normalizedPath.length`, which cuts the wrong span for encoded URLs.
+          let mountSegments = 1
+          for (let i = 1; i < normalizedPath.length; i++) {
+            if (normalizedPath.charCodeAt(i) === SLASH_CHAR_CODE) mountSegments++
+          }
           pathMiddlewares.push((req, _, next) => {
-            mutateRequestUrl(getRawMountPrefix(req.path, mountSegments), req)
+            const reqPath = req.path
+            mutateRequestUrl(
+              reqPath.indexOf('%') === -1
+                ? normalizedPath
+                : getRawMountPrefix(reqPath, mountSegments),
+              req
+            )
             next()
           })
           middlewaresByPath[normalizedPath] = pathMiddlewares
+          pathMountCount++
+
+          const segment = getFirstPathSegment(normalizedPath)
+          let candidates = mountsByFirstSegment[segment]
+          if (candidates === undefined) {
+            candidates = []
+            mountsByFirstSegment[segment] = candidates
+          }
+          candidates.push({ path: normalizedPath, mw: pathMiddlewares })
+          if (candidates.length > 1) {
+            candidates.sort((a, b) => b.path.length - a.path.length)
+          }
         }
 
         for (let i = 0; i < middlewares.length; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -834,3 +834,171 @@ test('.use() sub-router matches base path with query string', async t => {
     '/checkout/success with query string'
   )
 })
+
+test('multi-segment .use() mount runs path middleware', async t => {
+  const router = Router(final)
+
+  router.use('/admin/panel', (req, res, next) => {
+    if (req.headers.authorization !== 'secret') {
+      res.statusCode = 401
+      return res.end('unauthorized')
+    }
+    next()
+  })
+  router.get('/admin/panel/secret', (req, res) => res.end('secret data'))
+
+  const url = await runServer(t, router)
+
+  const denied = await got(new URL('/admin/panel/secret', url).toString(), {
+    resolveBodyOnly: false
+  })
+  t.is(denied.statusCode, 401)
+  t.is(denied.body, 'unauthorized')
+
+  t.is(
+    await got(new URL('/admin/panel/secret', url).toString(), {
+      headers: { authorization: 'secret' }
+    }),
+    'secret data'
+  )
+})
+
+test('multi-segment .use() mounts a sub-router', async t => {
+  const router = Router(final)
+  const subRouter = Router(final)
+
+  subRouter.get('/', (req, res) => res.end('api-root'))
+  subRouter.get('/info', (req, res) => res.end('api-info'))
+
+  router.use('/api/v1', subRouter)
+
+  const url = await runServer(t, router)
+
+  t.is(await got(new URL('/api/v1', url).toString()), 'api-root')
+  t.is(await got(new URL('/api/v1/info', url).toString()), 'api-info')
+})
+
+test('longest matching .use() mount wins over a shorter prefix', async t => {
+  const router = Router(final)
+
+  router.use('/admin', (req, res, next) => {
+    req.mount = 'admin'
+    next()
+  })
+  router.use('/admin/panel', (req, res, next) => {
+    req.mount = 'admin-panel'
+    next()
+  })
+  router.get('/admin/settings', (req, res) => res.end(req.mount))
+  router.get('/admin/panel/secret', (req, res) => res.end(req.mount))
+
+  const url = await runServer(t, router)
+
+  t.is(await got(new URL('/admin/settings', url).toString()), 'admin')
+  t.is(await got(new URL('/admin/panel/secret', url).toString()), 'admin-panel')
+})
+
+test('.use() trailing-slash mount still runs path middleware', async t => {
+  const router = Router(final)
+
+  router.use('/admin/', (req, res, next) => {
+    if (req.headers.authorization !== 'secret') {
+      res.statusCode = 401
+      return res.end('unauthorized')
+    }
+    next()
+  })
+  router.get('/admin/secret', (req, res) => res.end('secret data'))
+
+  const url = await runServer(t, router)
+
+  const denied = await got(new URL('/admin/secret', url).toString(), {
+    resolveBodyOnly: false
+  })
+  t.is(denied.statusCode, 401)
+  t.is(denied.body, 'unauthorized')
+
+  t.is(
+    await got(new URL('/admin/secret', url).toString(), {
+      headers: { authorization: 'secret' }
+    }),
+    'secret data'
+  )
+})
+
+test('.use() path middleware runs for a percent-encoded mount segment', async t => {
+  const router = Router(final)
+
+  router.use('/admin', (req, res, next) => {
+    if (req.headers.authorization !== 'secret') {
+      res.statusCode = 401
+      return res.end('unauthorized')
+    }
+    next()
+  })
+  router.get('/admin/secret', (req, res) => res.end('secret data'))
+
+  const url = await runServer(t, router)
+
+  for (const path of ['/admin/secret', '/%61dmin/secret', '/a%64min/secret']) {
+    const denied = await got(new URL(path, url).toString(), {
+      resolveBodyOnly: false
+    })
+    t.is(denied.statusCode, 401, `${path} should be unauthorized`)
+    t.is(denied.body, 'unauthorized')
+
+    t.is(
+      await got(new URL(path, url).toString(), {
+        headers: { authorization: 'secret' }
+      }),
+      'secret data',
+      `${path} should reach the handler after auth`
+    )
+  }
+})
+
+test('.use() strips an encoded mount before a nested handler sees the path', async t => {
+  const router = Router(final)
+  const subRouter = Router(final)
+
+  subRouter.get('/secret', (req, res) => {
+    res.end(`path=${req.path}`)
+  })
+
+  router.use('/admin', subRouter)
+
+  const url = await runServer(t, router)
+
+  t.is(
+    await got(new URL('/%61dmin/secret', url).toString()),
+    'path=/secret'
+  )
+})
+
+test('.use() multi-segment encoded mount still runs path middleware', async t => {
+  const router = Router(final)
+
+  router.use('/admin/panel', (req, res, next) => {
+    if (req.headers.authorization !== 'secret') {
+      res.statusCode = 401
+      return res.end('unauthorized')
+    }
+    next()
+  })
+  router.get('/admin/panel/secret', (req, res) => res.end('secret data'))
+
+  const url = await runServer(t, router)
+
+  const denied = await got(new URL('/%61dmin/panel/secret', url).toString(), {
+    resolveBodyOnly: false
+  })
+  t.is(denied.statusCode, 401)
+  t.is(denied.body, 'unauthorized')
+
+  t.is(
+    await got(new URL('/%61dmin/panel/secret', url).toString(), {
+      headers: { authorization: 'secret' }
+    }),
+    'secret data'
+  )
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1002,3 +1002,27 @@ test('.use() multi-segment encoded mount still runs path middleware', async t =>
     'secret data'
   )
 })
+
+test('.use() does not treat %2F as a mount separator', async t => {
+  const router = Router(final)
+  let mounted = false
+
+  router.use('/admin/panel', (req, res, next) => {
+    mounted = true
+    next()
+  })
+  router.get('/admin/panel/secret', (req, res) => res.end('panel'))
+
+  const url = await runServer(t, router)
+
+  mounted = false
+  const encoded = await got(new URL('/admin%2Fpanel/secret', url).toString(), {
+    resolveBodyOnly: false
+  })
+  t.is(encoded.statusCode, 404)
+  t.false(mounted, 'encoded slash must not match /admin/panel mount')
+
+  mounted = false
+  t.is(await got(new URL('/admin/panel/secret', url).toString()), 'panel')
+  t.true(mounted)
+})


### PR DESCRIPTION
## Summary
- Path middleware registered via `.use()` was looked up by the first URL segment only, so multi-segment mounts (`/admin/panel`), trailing-slash mounts (`/admin/`), and percent-encoded segments (`/%61dmin`) were skipped while matching routes still ran — an auth/guard bypass.
- Normalize mount paths on register, match the longest decoded prefix, and strip the raw URL prefix by segment count so nested handlers see the correct remaining path.
- Supersedes draft PRs #31, #32, and #33 with one combined fix and regression coverage for each case (including multi-segment + encoding).

## Test plan
- [x] Full suite: 52 tests passed
- [x] Multi-segment auth mount + sub-router (`/api/v1`)
- [x] Longest prefix wins over shorter mount
- [x] Trailing-slash mount still runs middleware
- [x] Percent-encoded mount segment still runs auth / strips path for nested handlers
- [x] Multi-segment + encoded mount (`/%61dmin/panel/secret`)


Made with [Cursor](https://cursor.com)